### PR TITLE
Corrected boolean handling in `Reflective.__len__`

### DIFF
--- a/src/reflective/types/base.py
+++ b/src/reflective/types/base.py
@@ -199,7 +199,10 @@ class Reflective:
     def __len__(self) -> int:
         # Ensure that this reference is valid
         self().enforce_validation()
-        return len(self().ref)
+        value = self().ref
+        if isinstance(value, bool):
+            return 1 if value is True else 0
+        return len(value)
 
 
 class RType(Reflective):

--- a/src/tests/test_bools.py
+++ b/src/tests/test_bools.py
@@ -1,0 +1,13 @@
+from reflective import Reflective
+
+
+def test_logic():
+    r = Reflective({'check': True})
+
+    if r.check:
+        assert True
+
+    if not r.check:
+        assert False
+
+    assert r.check


### PR DESCRIPTION
### Resolves: #18

Corrected the handling of boolean values in the `reflective.types.base.Reflective.__len__` method. A proper `1` is returned for `True` and `0` for `False`.

Additionally, I created a new test to verify the expected behavior.